### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/src/TinyStepper_28BYJ_48.h
+++ b/src/TinyStepper_28BYJ_48.h
@@ -11,7 +11,7 @@
 #ifndef TinyStepper_28BYJ_48_h
 #define TinyStepper_28BYJ_48_h
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdlib.h>
 
 


### PR DESCRIPTION
On a filename case-sensitive operating system like Linux, use of the incorrect filename case in an #include directive causes compilation to fail:
```
/home/per/Arduino/libraries/TinyStepper_28BYJ_48/src/TinyStepper_28BYJ_48.h:14:21: fatal error: arduino.h: No such file or directory
```